### PR TITLE
Add defer method to context and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This is done to acknowledge the interaction.
 A secondary action will need to be sent within 15 minutes through the follow-up webhook.
 
 Parameters:
-- ephemeral: ``Optional[bool]``
+- ephemeral: ``bool``
 - - Indicates whether the deferred message will eventually be ephemeral. Defaults to `False`
 
 Returns

--- a/README.md
+++ b/README.md
@@ -226,6 +226,26 @@ Returns
 - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
 - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
 
+> ``async def defer(self, *, ephemeral: bool = False) -> None:``
+
+
+Defers the given interaction.
+
+This is done to acknowledge the interaction.
+A secondary action will need to be sent within 15 minutes through the follow-up webhook.
+
+Parameters:
+- ephemeral: ``Optional[bool]``
+- - Indicates whether the deferred message will eventually be ephemeral. Defaults to `False`
+
+Returns
+- ``None``
+
+Raises
+- [``discord.HTTPException``](https://discordpy.readthedocs.io/en/master/api.html#discord.HTTPException)
+- - Deferring the interaction failed.
+- [``discord.InteractionResponded``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionResponded)
+- - This interaction has been responded to before.
 
 > ``property cog(self)``
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Parameters:
 - - A list of files to send with the message. Incompatible with ``file``.
 - ephemeral: ``bool``
 - - Whether the message should be ephemeral (only visible to the interaction user).
+- - Note: This field is ignored if the interaction was deferred.
 
 Returns
 - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.

--- a/slash_util.py
+++ b/slash_util.py
@@ -294,7 +294,7 @@ class Context(Generic[BotT, CogT]):
         - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
         - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
         """
-        if self.interaction.is_done():
+        if self.interaction.response.is_done():
             return await self.interaction.followup.send(content, wait=True, **kwargs)
 
         await self.interaction.response.send_message(content or None, **kwargs)

--- a/slash_util.py
+++ b/slash_util.py
@@ -285,6 +285,7 @@ class Context(Generic[BotT, CogT]):
         - - A list of files to send with the message. Incompatible with ``file``.
         - ephemeral: ``bool``
         - - Whether the message should be ephemeral (only visible to the interaction user).
+        - - Note: This field is ignored if the interaction was deferred.
         - tts: ``bool``
         - - Whether the message should be played via Text To Speech. Send TTS Messages permission is required.
         - view: [``discord.ui.View``](https://discordpy.readthedocs.io/en/master/api.html#discord.ui.View)

--- a/slash_util.py
+++ b/slash_util.py
@@ -310,7 +310,7 @@ class Context(Generic[BotT, CogT]):
         A secondary action will need to be sent within 15 minutes through the follow-up webhook.
 
         Parameters:
-        - ephemeral: ``Optional[bool]``
+        - ephemeral: ``bool``
         - - Indicates whether the deferred message will eventually be ephemeral. Defaults to `False`
 
         Returns

--- a/slash_util.py
+++ b/slash_util.py
@@ -253,7 +253,6 @@ class Context(Generic[BotT, CogT]):
         self.bot = bot
         self.command = command
         self.interaction = interaction
-        self._responded = False
 
     @overload
     def send(self, content: str = MISSING, *, embed: discord.Embed = MISSING, ephemeral: bool = MISSING, tts: bool = MISSING, view: discord.ui.View = MISSING, file: discord.File = MISSING) -> Coroutine[Any, Any, Union[discord.InteractionMessage, discord.WebhookMessage]]: ...
@@ -295,13 +294,34 @@ class Context(Generic[BotT, CogT]):
         - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
         - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
         """
-        if self._responded:
+        if self.interaction.is_done():
             return await self.interaction.followup.send(content, wait=True, **kwargs)
 
         await self.interaction.response.send_message(content or None, **kwargs)
-        self._responded = True
 
         return await self.interaction.original_message()
+
+    async def defer(self, *, ephemeral: bool = False) -> None:
+        """
+        Defers the given interaction.
+
+        This is done to acknowledge the interaction.
+        A secondary action will need to be sent within 15 minutes through the follow-up webhook.
+
+        Parameters:
+        - ephemeral: ``Optional[bool]``
+        - - Indicates whether the deferred message will eventually be ephemeral. Defaults to `False`
+
+        Returns
+        - ``None``
+
+        Raises
+        - [``discord.HTTPException``](https://discordpy.readthedocs.io/en/master/api.html#discord.HTTPException)
+        - - Deferring the interaction failed.
+        - [``discord.InteractionResponded``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionResponded)
+        - - This interaction has been responded to before.
+        """
+        await self.interaction.response.defer(ephemeral=ephemeral)
     
     @property
     def cog(self) -> CogT:


### PR DESCRIPTION
Added a defer method to the context object. This hasn't been tested yet so that would be good before merging. Also I updated documentation and tried to copy the current style but some changes may need to be made there.

Also removed the attribute `_responded` of context. Now uses `InteractionResponse.is_done()`