### PR TITLE
Adding support for Literal option choices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These parameters may only be used inside ``slash commands``, not within context 
 - ``bool`` for booleans
 - ``discord.User`` or ``discord.Member`` for members
 - ``discord.Role`` for roles
+- ``typing.Literal`` option choices (see [Literals](#literals) for more information)
 
 For defining channel parameters, they are documented in [Channels](#channels)
 
@@ -57,6 +58,20 @@ async def my_command(self, ctx, channel: typing.Union[discord.TextChannel, disco
   await ctx.send(f'{channel.mention} is not a category!', ephemeral=True)
 ```
 
+## Literals
+A [typing.Literal](https://docs.python.org/3/library/typing.html#typing.Literal) is a special type hint that requires the passed parameter to be equal to one of the listed values.
+The passed literals must be all the same type, which must be either ``str``, `int` or ``float``.
+These will be used to create a list of options for the user to select from.
+For example, given the following:
+
+```python
+from typing import Literal
+
+@slash_util.slash_command()
+async def shop(self, ctx, buy_sell: Literal['buy', 'sell'], amount: Literal[1, 2], item: str):
+    await ctx.send(f'{buy_sell.capitalize()}ing {amount} {item}(s)!')
+```
+The ``buy_sell`` parameter must be either the literal string ``"buy"`` or ``"sell"`` and amount must be the int ``1`` or ``2``. 
 ## Examples
 ``slash_util`` defines a bot subclass to automatically handle posting updated commands to discords api. This isn't required but highly recommended to use.
 ```python

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These parameters may only be used inside ``slash commands``, not within context 
 - ``bool`` for booleans
 - ``discord.User`` or ``discord.Member`` for members
 - ``discord.Role`` for roles
-- ``typing.Literal`` option choices (see [Literals](#literals) for more information)
+- ``typing.Literal`` for option choices (see [Literals](#literals) for more information)
 
 For defining channel parameters, they are documented in [Channels](#channels)
 

--- a/slash_util.py
+++ b/slash_util.py
@@ -438,7 +438,7 @@ class SlashCommand(Command[CogT]):
                     args = get_args(ann)
                     real_t = args[0]
                 elif get_origin(ann) is Literal:
-                    real_t = str
+                    real_t = type(ann.__args__[0])
                 else:
                     real_t = ann
 
@@ -467,7 +467,7 @@ class SlashCommand(Command[CogT]):
 
                 elif get_origin(ann) is Literal:
                     arguments = ann.__args__
-                    option['choices'] = [{'name': a, 'value': a} for a in arguments]
+                    option['choices'] = [{'name': str(a), 'value': a} for a in arguments]
 
                 elif issubclass(ann, discord.abc.GuildChannel):
                     option['channel_types'] = [channel_filter[ann]]

--- a/slash_util.py
+++ b/slash_util.py
@@ -11,7 +11,7 @@ import discord, discord.channel, discord.http, discord.state
 from discord.ext import commands
 from discord.utils import MISSING
 
-from typing import Coroutine, TypeVar, Union, get_args, get_origin, overload, Generic, TYPE_CHECKING
+from typing import Coroutine, TypeVar, Union, get_args, get_origin, overload, Generic, TYPE_CHECKING, Literal
 
 BotT = TypeVar("BotT", bound='Bot')
 CtxT = TypeVar("CtxT", bound='Context')
@@ -437,6 +437,8 @@ class SlashCommand(Command[CogT]):
                 elif get_origin(ann) is Union:
                     args = get_args(ann)
                     real_t = args[0]
+                elif get_origin(ann) is Literal:
+                    real_t = str
                 else:
                     real_t = ann
 
@@ -462,6 +464,10 @@ class SlashCommand(Command[CogT]):
                     if len(args) != 3:
                         filtered = [channel_filter[i] for i in args]
                         option['channel_types'] = filtered
+
+                elif get_origin(ann) is Literal:
+                    arguments = ann.__args__
+                    option['choices'] = [{'name': str(a), 'value': str(a)} for a in arguments]
 
                 elif issubclass(ann, discord.abc.GuildChannel):
                     option['channel_types'] = [channel_filter[ann]]

--- a/slash_util.py
+++ b/slash_util.py
@@ -467,7 +467,7 @@ class SlashCommand(Command[CogT]):
 
                 elif get_origin(ann) is Literal:
                     arguments = ann.__args__
-                    option['choices'] = [{'name': str(a), 'value': str(a)} for a in arguments]
+                    option['choices'] = [{'name': a, 'value': a} for a in arguments]
 
                 elif issubclass(ann, discord.abc.GuildChannel):
                     option['channel_types'] = [channel_filter[ann]]


### PR DESCRIPTION
Here is my implementation of literal options I had made a few weeks ago in [my gist fork](https://gist.github.com/LeoCx1000/6310c1864c0b992128cc6bc74086fdf7/revisions), glad to be finally able to make PRs.
here's an example:

```py
import typing
AllowedWords = typing.Literal['First', 'Second', 'Third', 'Fourth']

@slash_util.slash_command(name="test", guild_id=774561547930304536)
async def test(self, ctx: slash_utils.Context, option: AllowedWords):
    await ctx.send(f"option: {option}")
```

![example](https://cdn.duck-bot.com/file/olhy0hoFER.png)
![example2](https://cdn.duck-bot.com/file/jpNbNZU3Cr.png)

I apologize for this lack of documentation 😦 and sorry if this was already PRed, I had some struggles understanding the interface