### PR TITLE
Fixing a TypeError when sending files.

### DIFF
--- a/slash_util/context.py
+++ b/slash_util/context.py
@@ -76,7 +76,7 @@ class Context(Generic[BotT, CogT]):
         - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
         - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
         """
-        if kwargs.get("file") or kwargs.get('files'):
+        if kwargs.get('file') or kwargs.get('files'):
             await self.defer(ephemeral=kwargs.get('ephemeral', False))
 
         if self.interaction.response.is_done():

--- a/slash_util/context.py
+++ b/slash_util/context.py
@@ -76,7 +76,7 @@ class Context(Generic[BotT, CogT]):
         - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
         - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
         """
-        if kwargs.get('file') or kwargs.get('files'):
+        if (kwargs.get('file') or kwargs.get('files')) and not self.interaction.response.is_done():
             await self.defer(ephemeral=kwargs.get('ephemeral', False))
 
         if self.interaction.response.is_done():

--- a/slash_util/context.py
+++ b/slash_util/context.py
@@ -76,6 +76,9 @@ class Context(Generic[BotT, CogT]):
         - [``discord.InteractionMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.InteractionMessage) if this is the first time responding.
         - [``discord.WebhookMessage``](https://discordpy.readthedocs.io/en/master/api.html#discord.WebhookMessage) for consecutive responses.
         """
+        if kwargs.get("file") or kwargs.get('files'):
+            await self.defer(ephemeral=kwargs.get('ephemeral', False))
+
         if self.interaction.response.is_done():
             return await self.interaction.followup.send(content, wait=True, **kwargs)
 


### PR DESCRIPTION
When you tried to send a file without deferring the interaction first you would get ``TypeError: InteractionResponse.send_message() got an unexpected keyword argument 'file'``. This PR is just to fix that by deferring the interaction response if the file or files kwarg has been passed and it hasn't been deferred before.