### PR TITLE
Add support for discord.Attachment options

### DIFF
--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -85,7 +85,7 @@ command_type_map: dict[type[Any], int] = {
     discord.CategoryChannel: 7,
     discord.Role: 8,
     float: 10,
-    discord.message.Attachment: 11
+    discord.Attachment: 11
 }
 
 channel_filter: dict[type[discord.abc.GuildChannel], int] = {

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -64,6 +64,13 @@ def _parse_resolved_data(interaction: discord.Interaction, data, state: discord.
         for id, d in resolved_roles.items():
             role = discord.Role(guild=interaction.guild, state=state, data=d)
             resolved[int(id)] = role
+         
+    resolved_attachments = data.get('attachments')
+    if resolved_attachments:
+        for id, d in resolved_attachments.items():
+            attachment = discord.Attachment(state=state, data=d)
+            resolved[int(id)] = attachment
+            
 
     return resolved
 
@@ -77,7 +84,8 @@ command_type_map: dict[type[Any], int] = {
     discord.VoiceChannel: 7,
     discord.CategoryChannel: 7,
     discord.Role: 8,
-    float: 10
+    float: 10,
+    discord.Attachment: 11
 }
 
 channel_filter: dict[type[discord.abc.GuildChannel], int] = {

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -223,10 +223,7 @@ class SlashCommand(Command[CogT]):
         result = {}
         for option in interaction.data['options']:
             value = option['value']
-            if option['type'] in (6, 7, 8):
-                value = resolved[int(value)]
-            
-            if option['type'] == 11:
+            if option['type'] in (6, 7, 8, 11):
                 value = resolved[int(value)]
 
             result[option['name']] = value

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -85,7 +85,7 @@ command_type_map: dict[type[Any], int] = {
     discord.CategoryChannel: 7,
     discord.Role: 8,
     float: 10,
-    discord.Attachment: 11
+    discord.message.Attachment: 11
 }
 
 channel_filter: dict[type[discord.abc.GuildChannel], int] = {

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -85,7 +85,7 @@ command_type_map: dict[type[Any], int] = {
     discord.CategoryChannel: 7,
     discord.Role: 8,
     float: 10,
-    discord.message.Attachment: 11
+    discord.Attachment: 11
 }
 
 channel_filter: dict[type[discord.abc.GuildChannel], int] = {
@@ -283,6 +283,7 @@ class SlashCommand(Command[CogT]):
                     real_t = type(ann.__args__[0])
                 else:
                     real_t = ann
+                    print(real_t)
 
                 typ = command_type_map[real_t]
                 option = {

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -283,7 +283,6 @@ class SlashCommand(Command[CogT]):
                     real_t = type(ann.__args__[0])
                 else:
                     real_t = ann
-                    print(real_t)
 
                 typ = command_type_map[real_t]
                 option = {

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -225,6 +225,7 @@ class SlashCommand(Command[CogT]):
             value = option['value']
             if option['type'] in (6, 7, 8, 11):
                 value = resolved[int(value)]
+                print(value)
 
             result[option['name']] = value
         return result

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -225,7 +225,6 @@ class SlashCommand(Command[CogT]):
             value = option['value']
             if option['type'] in (6, 7, 8, 11):
                 value = resolved[int(value)]
-                print(value)
 
             result[option['name']] = value
         return result

--- a/slash_util/core.py
+++ b/slash_util/core.py
@@ -225,6 +225,9 @@ class SlashCommand(Command[CogT]):
             value = option['value']
             if option['type'] in (6, 7, 8):
                 value = resolved[int(value)]
+            
+            if option['type'] == 11:
+                value = resolved[int(value)]
 
             result[option['name']] = value
         return result


### PR DESCRIPTION
Finally. Added support for option type 11 `discord.Attachment`. It was **tested**.
(See #9)

## (idk why I added that much commits. Ignore them)

(_I am not good at using GitHub/changing source code, if I have anything that I can improve, pls tell me. Thanks._)
(_next time I will test the code first on my local computer before I commit._)